### PR TITLE
tools: suiTransferTool: Added support for Suins names

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Examples:
 - `transfer 1 sui to 0x1234567890abcdef`
 - `send 10 sui to 0x1234567890abcdef`
 - `donate 1 sui to @abcdef1234567890`
-- `donate 1 sui to abcdef1234567890.sui`
+- `throw 1 sui to abcdef1234567890.sui`
 
 ### suiSwapTool (mainnet only)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Transfers the specified amount of SUI to the specified address.
 Examples:
 - `transfer 1 sui to 0x1234567890abcdef`
 - `send 10 sui to 0x1234567890abcdef`
+- `donate 1 sui to @abcdef1234567890`
+- `donate 1 sui to abcdef1234567890.sui`
 
 ### suiSwapTool (mainnet only)
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,14 @@ pnpm start:openai:generating
 
 ## Future vision
 
-- Improve suiTransferTool: SuiNS support, support for other tokens
-- Add more tools: staking, lending, pools, etc.
-- Add more services: Suilend, Bluefin, Cetus, DefiLlama, etc.
-- Add more model providers: Atoma, local models
-- Implement Command scheduling
-- Add Web UI examples
-- Create automated tests
+- [x] Improve suiTransferTool: add support for SuiNS names
+- [ ] Improve suiTransferTool: add support for other tokens
+- [ ] Add more tools: staking, lending, pools, etc.
+- [ ] Add more services: Suilend, Bluefin, Cetus, DefiLlama, etc.
+- [ ] Add more model providers: Atoma, local models
+- [ ] Implement Command scheduling
+- [ ] Add Web UI examples
+- [ ] Create automated tests
 
 ## How to contribute
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "suiware-ai-tools",
   "scripts": {
     "build": "pnpm --filter @suiware/ai-tools build",
-    "start": "pnpm --filter examples start:anthropic:streaming",
+    "start": "pnpm build && pnpm --filter examples start:anthropic:streaming",
     "start:anthropic:streaming": "pnpm build && pnpm --filter examples start:anthropic:streaming",
     "start:anthropic:simple:balance": "pnpm build && pnpm --filter examples start:anthropic:simple:balance",
     "start:openai:streaming": "pnpm build && pnpm --filter examples start:openai:streaming",

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -60,6 +60,8 @@ Transfers the specified amount of SUI to the specified address.
 Examples:
 - `transfer 1 sui to 0x1234567890abcdef`
 - `send 10 sui to 0x1234567890abcdef`
+- `donate 1 sui to @abcdef1234567890`
+- `donate 1 sui to abcdef1234567890.sui`
 
 ### suiSwapTool (mainnet only)
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -61,7 +61,7 @@ Examples:
 - `transfer 1 sui to 0x1234567890abcdef`
 - `send 10 sui to 0x1234567890abcdef`
 - `donate 1 sui to @abcdef1234567890`
-- `donate 1 sui to abcdef1234567890.sui`
+- `throw 1 sui to abcdef1234567890.sui`
 
 ### suiSwapTool (mainnet only)
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -76,6 +76,7 @@
   },
   "dependencies": {
     "@mysten/sui": "^1.21.2",
+    "@mysten/suins": "^0.7.2",
     "@mysten/wallet-standard": "^0.13.26",
     "ai": "^4.1.37",
     "bignumber.js": "^9.1.2",

--- a/packages/tools/src/ai/tools/suiTransferTool.ts
+++ b/packages/tools/src/ai/tools/suiTransferTool.ts
@@ -3,6 +3,7 @@ import { tool } from 'ai'
 import z from 'zod'
 import { formatBalance } from '../../core/utils/utils'
 import { SuiService } from '../../services/SuiService'
+import { SuinsService } from '../../services/SuinsService'
 
 export const suiTransferTool = tool({
   description: 'Transfer the amount of SUI to the specified address',
@@ -10,12 +11,17 @@ export const suiTransferTool = tool({
     amount: z.number().describe('The amount of SUI'),
     address: z
       .string()
-      .refine(SuiService.isValidSuiAddress, { message: 'Invalid Sui address' })
+      .refine(
+        (value: string) =>
+          SuiService.isValidSuiAddress(value) ||
+          SuinsService.isValidSuinsName(value),
+        { message: 'Invalid Sui address' }
+      )
       .describe('The target address'),
   }),
   execute: async ({ amount, address }) => {
-    return console.log('address valid');
-    
+    return console.log('address valid')
+
     const suiService = new SuiService()
 
     const txDigest = await suiService.nativeTransfer(

--- a/packages/tools/src/ai/tools/suiTransferTool.ts
+++ b/packages/tools/src/ai/tools/suiTransferTool.ts
@@ -17,15 +17,24 @@ export const suiTransferTool = tool({
           SuinsService.isValidSuinsName(value),
         { message: 'Invalid Sui address' }
       )
-      .describe('The target address'),
+      .describe('The target address. Suins names starting with @ or ending with .sui are supported.'),
   }),
   execute: async ({ amount, address }) => {
-    return console.log('address valid')
-
     const suiService = new SuiService()
 
+    let resolvedAddress: string | null = address
+
+    // If it's a Suins name, try to resolve it a Sui address.
+    if (SuinsService.isValidSuinsName(address)) {
+      const suinsService = new SuinsService(suiService.getSuiClient())
+      resolvedAddress = await suinsService.resolveSuinsName(address)
+      if (!resolvedAddress) {
+        throw new Error(`Suins name ${address} not found`)
+      }
+    }
+
     const txDigest = await suiService.nativeTransfer(
-      address as `0x{string}`,
+      resolvedAddress as `0x{string}`,
       amount
     )
 

--- a/packages/tools/src/ai/tools/suiTransferTool.ts
+++ b/packages/tools/src/ai/tools/suiTransferTool.ts
@@ -14,6 +14,8 @@ export const suiTransferTool = tool({
       .describe('The target address'),
   }),
   execute: async ({ amount, address }) => {
+    return console.log('address valid');
+    
     const suiService = new SuiService()
 
     const txDigest = await suiService.nativeTransfer(

--- a/packages/tools/src/services/SuiService.ts
+++ b/packages/tools/src/services/SuiService.ts
@@ -25,6 +25,15 @@ export class SuiService {
   }
 
   /**
+   * Get the SuiClient instance.
+   *
+   * @returns {SuiClient} - SuiClient instance
+   */
+  public getSuiClient(): SuiClient {
+    return this.client
+  }
+
+  /**
    * Execute a transaction.
    *
    * @param transaction - The transaction block to execute.

--- a/packages/tools/src/services/SuinsService.ts
+++ b/packages/tools/src/services/SuinsService.ts
@@ -1,9 +1,7 @@
-import { getFullnodeUrl, SuiClient } from '@mysten/sui/client'
+import { SuiClient } from '@mysten/sui/client'
 import { SuinsClient } from '@mysten/suins'
-import { getSetting } from '../core/utils/environment'
-import { TSuiNetwork } from '../types/TSuiNetwork'
 
-export class SuiService {
+export class SuinsService {
   private suinsClient: SuinsClient
   private suiClient: SuiClient
 
@@ -12,14 +10,17 @@ export class SuiService {
 
     this.suinsClient = new SuinsClient({
       client: this.suiClient,
-      network: getFullnodeUrl(
-        getSetting('SUI_NETWORK') as Pick<TSuiNetwork, 'testnet' | 'mainnet'>
-      ),
+      // We rely on the network set through the SuiClient.
+      // network: getSetting('SUI_NETWORK') as Network,
     })
   }
 
   public async resolveSuinsName(name: string): Promise<string | null> {
     const nameRecord = await this.suinsClient.getNameRecord(name)
     return nameRecord?.targetAddress || null
+  }
+
+  public static isValidSuinsName(name: string): boolean {
+    return name.endsWith('.sui') || name.startsWith('@')
   }
 }

--- a/packages/tools/src/services/SuinsService.ts
+++ b/packages/tools/src/services/SuinsService.ts
@@ -1,0 +1,25 @@
+import { getFullnodeUrl, SuiClient } from '@mysten/sui/client'
+import { SuinsClient } from '@mysten/suins'
+import { getSetting } from '../core/utils/environment'
+import { TSuiNetwork } from '../types/TSuiNetwork'
+
+export class SuiService {
+  private suinsClient: SuinsClient
+  private suiClient: SuiClient
+
+  constructor(suiClient: SuiClient) {
+    this.suiClient = suiClient
+
+    this.suinsClient = new SuinsClient({
+      client: this.suiClient,
+      network: getFullnodeUrl(
+        getSetting('SUI_NETWORK') as Pick<TSuiNetwork, 'testnet' | 'mainnet'>
+      ),
+    })
+  }
+
+  public async resolveSuinsName(name: string): Promise<string | null> {
+    const nameRecord = await this.suinsClient.getNameRecord(name)
+    return nameRecord?.targetAddress || null
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@mysten/sui':
         specifier: ^1.21.2
         version: 1.21.2(typescript@5.7.3)
+      '@mysten/suins':
+        specifier: ^0.7.2
+        version: 0.7.2(typescript@5.7.3)
       '@mysten/wallet-standard':
         specifier: ^0.13.26
         version: 0.13.26(typescript@5.7.3)
@@ -790,6 +793,10 @@ packages:
     resolution: {integrity: sha512-8AesvczokAUv796XiOo8af2+1IYA9bRon11Ra+rwehvqhz+sMRT8A+Cw5sDnlSc9/aQwM51JQKUnvMczNbpfYA==}
     engines: {node: '>=18'}
 
+  '@mysten/suins@0.7.2':
+    resolution: {integrity: sha512-Jmvs54zQdHnv7lhL5RRM6ZydGj4XAM805SpPkStpXtqA3boDjndGYJqbqhhE8JJkotk28hi3YispZfRdMYH21A==}
+    engines: {node: '>=16'}
+
   '@mysten/wallet-standard@0.13.26':
     resolution: {integrity: sha512-0fRHmQ5RS0WEeSyfzdqrOWLssrZwDgR9Mw7Qhsfzq1UyDlS/GXYoL+dKpH+Uqfan33lt6hROPeXFyqw/vmF9Zg==}
 
@@ -1037,6 +1044,9 @@ packages:
 
   axios-retry@3.9.1:
     resolution: {integrity: sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==}
+
+  axios@0.24.0:
+    resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
 
   axios@1.7.9:
     resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
@@ -2274,6 +2284,17 @@ snapshots:
       - '@gql.tada/vue-support'
       - typescript
 
+  '@mysten/suins@0.7.2(typescript@5.7.3)':
+    dependencies:
+      '@mysten/sui': 1.21.2(typescript@5.7.3)
+      axios: 0.24.0
+      axios-retry: 3.9.1
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - debug
+      - typescript
+
   '@mysten/wallet-standard@0.13.26(typescript@5.7.3)':
     dependencies:
       '@mysten/sui': 1.21.2(typescript@5.7.3)
@@ -2512,6 +2533,12 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.7
       is-retry-allowed: 2.2.0
+
+  axios@0.24.0:
+    dependencies:
+      follow-redirects: 1.15.9
+    transitivePeerDependencies:
+      - debug
 
   axios@1.7.9:
     dependencies:


### PR DESCRIPTION
Now it's possible to send Sui to Suins names, for example:

`donate 1 sui to @abcdef1234567890` or `send 1 sui to abcdef1234567890.sui`

_* These are fake addresses, provided just for example._